### PR TITLE
[JENKINS-28502] fixed Groovy crawler

### DIFF
--- a/groovy.groovy
+++ b/groovy.groovy
@@ -6,13 +6,13 @@ import net.sf.json.*
 import com.gargoylesoftware.htmlunit.WebClient
 
 def wc = new WebClient()
-def baseUrl = 'http://dist.groovy.codehaus.org/distributions/'
+def baseUrl = 'https://dl.bintray.com/groovy/maven/'
 HtmlPage p = wc.getPage(baseUrl);
 
 def json = [];
 
 p.selectNodes("//a[@href]").reverse().collect { HtmlAnchor e ->
-    def url = baseUrl + e.getHrefAttribute()
+    def url = baseUrl + e.getHrefAttribute()[1..-1]
     println url
     def m = (url =~ /groovy-binary-(\d.\d.\d).zip$/)
     if (m) {


### PR DESCRIPTION
Groovy distributions are hosted on Bintray after Codehaus was shut down.

In line 15 I had to remove a leading # from the URL which is done by JavaScript on the Bintray page.