### PR TITLE
URGENT: Builds are failing because Apache Maven cannot be downloaded (correctly) from archive.apache.org

### DIFF
--- a/maven.groovy
+++ b/maven.groovy
@@ -72,7 +72,7 @@ def listFromNewUrl() {
 }
 
 def listAll() {
-    return (listFromOldURL() + listFromNewUrl())
+    return (listFromNewUrl() + listFromOldURL())
             .unique { o1, o2 -> o1.id <=> o2.id }
             .sort { o1, o2 ->
                 try {

--- a/maven.groovy
+++ b/maven.groovy
@@ -61,14 +61,14 @@ def listFromUrl(url, pattern) {
 
 // Archives are coming from Apache
 def listFromOldURL() {
-    return listFromURL("http://archive.apache.org/dist/maven/binaries/")
+    return listFromURL("https://archive.apache.org/dist/maven/binaries/")
 }
 
 // Recent releases are coming from Maven central
 // Discussed with the Maven team here
 // http://mail-archives.apache.org/mod_mbox/maven-dev/201505.mbox/%3cCAFNCU--iq2nYb3wnO715CbcXN+S8umRTyRnfk4_JSZ2qCR+1fg@mail.gmail.com%3e
 def listFromNewUrl() {
-    return listFromUrl("http://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/", "maven-([0-9.]+)(-bin)?.zip\$")
+    return listFromUrl("https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/", "maven-([0-9.]+)(-bin)?.zip\$")
 }
 
 def listAll() {


### PR DESCRIPTION
archive.apache.org is really slow today due to a recent outage:  https://twitter.com/infrabot/status/717964322790445056 
This slowness fails a lot of builds because jenkins doesn't succeed to download Maven (enough quickly) before hiting the download timeout. 
I found a bug in our script which prefers to use archive.apache.org instead of Maven central which is wrong because archive.a.o isn't at all usable for massive downloads. 
With this fix we are using central for all releases >= 2.0.9 while before we were using it only for >= 3.2.3 :( 
I also switched to https like for many others tools