### PR TITLE
Cut over to new sdkman endpoint for grails versions.

### DIFF
--- a/grails.groovy
+++ b/grails.groovy
@@ -3,7 +3,7 @@
 import net.sf.json.*
 
 def json = []
-def versions = new URL('http://api.sdkman.io/candidates/grails').text.split(',').reverse()
+def versions = new URL('https://api.sdkman.io/2/candidates/grails/universal/versions/all').text.split(',').reverse()
 versions.each {
     json << [id:it, name:"Grails $it".toString(), url:"https://github.com/grails/grails-core/releases/download/v${it}/grails-${it}.zip".toString()]
 }


### PR DESCRIPTION
The api that was being called was orphaned, so I wrote a new endpoint that serves the purpose required here. New versions will now show up as expected.